### PR TITLE
[DRAFT] Support Windows environment variables within env file paths

### DIFF
--- a/__tests__/test-parsing.js
+++ b/__tests__/test-parsing.js
@@ -8,3 +8,8 @@ test('expands environment variables ', () => {
     var homedir = process.env.HOME
     expect(index.run('', env, 'HOMEDIR')).toEqual(homedir);
 })
+test('return correct key value when environment variables in env filepath', () => {
+    process.env.CWD = process.cwd();
+    const envWithVar = '%CWD%/__tests__/.env.test';
+    expect(index.run('', envWithVar, 'CHEESE')).toEqual('CAKE');
+})

--- a/index.js
+++ b/index.js
@@ -3,6 +3,10 @@ const dotenvExpand = require('dotenv-expand');
 
 const fs = require('fs');
 
+const expandPath = function( path ) {
+  return path.replace(/%([^%]+)%/g, (_,n) => process.env[n] ?? '')
+}
+
 const parse = function( config ) {
   var newObj = { 
       ignoreProcessEnv: false, 
@@ -33,12 +37,15 @@ module.exports.templateTags = [
       } 
     ],
     run(context, path, varName) {
-      fs.stat(path, function(err) {
+
+      let expandedPath = expandPath(path);
+
+      fs.stat(expandedPath, function(err) {
         if (err && err.code === 'ENOENT')
           console.log('File or directory not found');
-      });
-
-      const config = dotenv.parse(fs.readFileSync(path));
+      });      
+      
+      const config = dotenv.parse(fs.readFileSync(expandedPath));
       dotenvExpand.expand( parse(config) );
 
 


### PR DESCRIPTION
DRAFT - still in testing!

Adding support for expanding Windows environment variables within .env filepaths.

e.g.  before change:

`C:\/Users\/James\/.insomnia.env` but this is specific to my username

after change:

`%USERPROFILE%\/.insomnia.env`